### PR TITLE
Turn the sample app into a chat app with a broad snapshot suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: screenshotbot_ci
-    resource_class: m2pro.medium
+    resource_class: m4pro.medium
     steps:
       - checkout
       - run: bundle install
@@ -28,7 +28,7 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
-    resource_class: m2pro.medium
+    resource_class: m4pro.medium
     steps:
       - checkout
       - run: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: screenshotbot_ci
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.medium
     steps:
       - checkout
       - run: bundle install
@@ -28,6 +28,7 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
+    resource_class: m2pro.medium
     steps:
       - checkout
       - run: bundle install

--- a/SimpleProject.xcodeproj/project.pbxproj
+++ b/SimpleProject.xcodeproj/project.pbxproj
@@ -16,6 +16,18 @@
 		AF5E1F9E2B485E1E0093784D /* SimpleProjectUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5E1F9D2B485E1E0093784D /* SimpleProjectUITestsLaunchTests.swift */; };
 		AF8DD5182B85304800139ED2 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AF8DD5172B85304800139ED2 /* SnapshotTesting */; };
 		AFLOGIN12345678901234567 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFLOGIN98765432109876543 /* LoginView.swift */; };
+		AFCHA7000000000000000002 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000001 /* ChatModels.swift */; };
+		AFCHA7000000000000000004 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000003 /* Strings.swift */; };
+		AFCHA7000000000000000006 /* ChatSampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000005 /* ChatSampleData.swift */; };
+		AFCHA7000000000000000008 /* ChatComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000007 /* ChatComponents.swift */; };
+		AFCHA700000000000000000A /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000009 /* MessageBubbleView.swift */; };
+		AFCHA700000000000000000C /* ConversationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA700000000000000000B /* ConversationListView.swift */; };
+		AFCHA700000000000000000E /* ChatDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA700000000000000000D /* ChatDetailView.swift */; };
+		AFCHA7000000000000000010 /* SnapshotSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA700000000000000000F /* SnapshotSupport.swift */; };
+		AFCHA7000000000000000012 /* ChatSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000011 /* ChatSnapshotTests.swift */; };
+		AFCHA7000000000000000014 /* ChatComponentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000013 /* ChatComponentSnapshotTests.swift */; };
+		AFCHA7000000000000000016 /* LocalizationSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000015 /* LocalizationSnapshotTests.swift */; };
+		AFCHA7000000000000000018 /* DynamicTypeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCHA7000000000000000017 /* DynamicTypeSnapshotTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +59,18 @@
 		AF5E1F9B2B485E1E0093784D /* SimpleProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleProjectUITests.swift; sourceTree = "<group>"; };
 		AF5E1F9D2B485E1E0093784D /* SimpleProjectUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleProjectUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		AFLOGIN98765432109876543 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000001 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000003 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000005 /* ChatSampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSampleData.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000007 /* ChatComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComponents.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000009 /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
+		AFCHA700000000000000000B /* ConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListView.swift; sourceTree = "<group>"; };
+		AFCHA700000000000000000D /* ChatDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDetailView.swift; sourceTree = "<group>"; };
+		AFCHA700000000000000000F /* SnapshotSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotSupport.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000011 /* ChatSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSnapshotTests.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000013 /* ChatComponentSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComponentSnapshotTests.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000015 /* LocalizationSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationSnapshotTests.swift; sourceTree = "<group>"; };
+		AFCHA7000000000000000017 /* DynamicTypeSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeSnapshotTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +123,13 @@
 		AF5E1F7F2B485E1C0093784D /* SimpleProject */ = {
 			isa = PBXGroup;
 			children = (
+				AFCHA7000000000000000001 /* ChatModels.swift */,
+				AFCHA7000000000000000003 /* Strings.swift */,
+				AFCHA7000000000000000005 /* ChatSampleData.swift */,
+				AFCHA7000000000000000007 /* ChatComponents.swift */,
+				AFCHA7000000000000000009 /* MessageBubbleView.swift */,
+				AFCHA700000000000000000B /* ConversationListView.swift */,
+				AFCHA700000000000000000D /* ChatDetailView.swift */,
 				AF5E1F802B485E1C0093784D /* SimpleProjectApp.swift */,
 				AF5E1F822B485E1C0093784D /* ContentView.swift */,
 				AFLOGIN98765432109876543 /* LoginView.swift */,
@@ -119,6 +150,11 @@
 		AF5E1F902B485E1E0093784D /* SimpleProjectTests */ = {
 			isa = PBXGroup;
 			children = (
+				AFCHA700000000000000000F /* SnapshotSupport.swift */,
+				AFCHA7000000000000000011 /* ChatSnapshotTests.swift */,
+				AFCHA7000000000000000013 /* ChatComponentSnapshotTests.swift */,
+				AFCHA7000000000000000015 /* LocalizationSnapshotTests.swift */,
+				AFCHA7000000000000000017 /* DynamicTypeSnapshotTests.swift */,
 				AF5E1F912B485E1E0093784D /* SimpleProjectTests.swift */,
 			);
 			path = SimpleProjectTests;
@@ -280,6 +316,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AFCHA7000000000000000002 /* ChatModels.swift in Sources */,
+				AFCHA7000000000000000004 /* Strings.swift in Sources */,
+				AFCHA7000000000000000006 /* ChatSampleData.swift in Sources */,
+				AFCHA7000000000000000008 /* ChatComponents.swift in Sources */,
+				AFCHA700000000000000000A /* MessageBubbleView.swift in Sources */,
+				AFCHA700000000000000000C /* ConversationListView.swift in Sources */,
+				AFCHA700000000000000000E /* ChatDetailView.swift in Sources */,
 				AF5E1F832B485E1C0093784D /* ContentView.swift in Sources */,
 				AFLOGIN12345678901234567 /* LoginView.swift in Sources */,
 				AF5E1F812B485E1C0093784D /* SimpleProjectApp.swift in Sources */,
@@ -290,6 +333,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AFCHA7000000000000000010 /* SnapshotSupport.swift in Sources */,
+				AFCHA7000000000000000012 /* ChatSnapshotTests.swift in Sources */,
+				AFCHA7000000000000000014 /* ChatComponentSnapshotTests.swift in Sources */,
+				AFCHA7000000000000000016 /* LocalizationSnapshotTests.swift in Sources */,
+				AFCHA7000000000000000018 /* DynamicTypeSnapshotTests.swift in Sources */,
 				AF5E1F922B485E1E0093784D /* SimpleProjectTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SimpleProject/ChatComponents.swift
+++ b/SimpleProject/ChatComponents.swift
@@ -65,7 +65,7 @@ struct DeliveryTicksView: View {
                 .padding(.trailing, 4)
             }
         }
-        .font(.system(size: 11, weight: .bold))
+        .font(.caption2.weight(.bold))
         .foregroundStyle(status == .read ? Color(red: 0.45, green: 0.85, blue: 1.0) : tint)
     }
 }
@@ -113,7 +113,7 @@ struct UnreadBadge: View {
 
     var body: some View {
         Text("\(count)")
-            .font(.system(size: 13, weight: .semibold))
+            .font(.footnote.weight(.semibold))
             .monospacedDigit()
             .foregroundStyle(.white)
             .padding(.horizontal, count > 9 ? 7 : 0)
@@ -146,7 +146,7 @@ struct UnreadDivider: View {
         HStack(spacing: 8) {
             Rectangle().fill(Color.accentColor.opacity(0.35)).frame(height: 1)
             Text(label.uppercased())
-                .font(.system(size: 10, weight: .bold))
+                .font(.caption2.weight(.bold))
                 .foregroundStyle(Color.accentColor)
             Rectangle().fill(Color.accentColor.opacity(0.35)).frame(height: 1)
         }

--- a/SimpleProject/ChatComponents.swift
+++ b/SimpleProject/ChatComponents.swift
@@ -1,0 +1,155 @@
+//
+//  ChatComponents.swift
+//  SimpleProject
+//
+//  Small building blocks shared by the conversation list and the chat detail
+//  screen. Nothing here animates: snapshots need every run to render the same
+//  pixels.
+//
+
+import SwiftUI
+
+/// Circular avatar with the contact's initials over their tint, plus an
+/// optional presence dot.
+struct AvatarView: View {
+    let contact: Contact
+    var size: CGFloat = 52
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Circle()
+                .fill(contact.tint.gradient)
+                .frame(width: size, height: size)
+                .overlay {
+                    if contact.isGroup {
+                        Image(systemName: "person.2.fill")
+                            .font(.system(size: size * 0.36, weight: .semibold))
+                            .foregroundStyle(.white)
+                    } else {
+                        Text(contact.initials)
+                            .font(.system(size: size * 0.38, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white)
+                    }
+                }
+
+            if contact.isOnline {
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: size * 0.28, height: size * 0.28)
+                    .overlay {
+                        Circle().stroke(Color(uiColor: .systemBackground), lineWidth: size * 0.05)
+                    }
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+/// The sending / sent / delivered / read ticks on outgoing messages.
+struct DeliveryTicksView: View {
+    let status: DeliveryStatus
+    var tint: Color = .white.opacity(0.75)
+
+    var body: some View {
+        Group {
+            switch status {
+            case .sending:
+                Image(systemName: "clock")
+            case .sent:
+                Image(systemName: "checkmark")
+            case .delivered, .read:
+                ZStack(alignment: .leading) {
+                    Image(systemName: "checkmark")
+                    Image(systemName: "checkmark").offset(x: 4)
+                }
+                .padding(.trailing, 4)
+            }
+        }
+        .font(.system(size: 11, weight: .bold))
+        .foregroundStyle(status == .read ? Color(red: 0.45, green: 0.85, blue: 1.0) : tint)
+    }
+}
+
+/// Static three-dot "typing" bubble.
+struct TypingIndicatorView: View {
+    private let opacities: [Double] = [0.35, 0.6, 0.9]
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(Array(opacities.enumerated()), id: \.offset) { _, opacity in
+                Circle()
+                    .fill(Color.secondary.opacity(opacity))
+                    .frame(width: 7, height: 7)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .secondarySystemBackground), in: Capsule())
+    }
+}
+
+/// Fixed-height bars standing in for an audio waveform.
+struct WaveformView: View {
+    let samples: [CGFloat]
+    let tint: Color
+    var height: CGFloat = 26
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 2.5) {
+            ForEach(Array(samples.enumerated()), id: \.offset) { _, sample in
+                Capsule()
+                    .fill(tint)
+                    .frame(width: 2.5, height: max(3, sample * height))
+            }
+        }
+        .frame(height: height)
+    }
+}
+
+/// Rounded pill used for unread counts.
+struct UnreadBadge: View {
+    let count: Int
+    var muted: Bool = false
+
+    var body: some View {
+        Text("\(count)")
+            .font(.system(size: 13, weight: .semibold))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .padding(.horizontal, count > 9 ? 7 : 0)
+            .frame(minWidth: 22, minHeight: 22)
+            .background(muted ? Color.secondary.opacity(0.6) : Color.accentColor, in: Capsule())
+    }
+}
+
+/// Centred date pill between message groups.
+struct DaySeparator: View {
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+            .background(Color(uiColor: .secondarySystemBackground), in: Capsule())
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+    }
+}
+
+/// Full-width rule marking where the unread messages begin.
+struct UnreadDivider: View {
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle().fill(Color.accentColor.opacity(0.35)).frame(height: 1)
+            Text(label.uppercased())
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(Color.accentColor)
+            Rectangle().fill(Color.accentColor.opacity(0.35)).frame(height: 1)
+        }
+        .padding(.vertical, 10)
+    }
+}

--- a/SimpleProject/ChatDetailView.swift
+++ b/SimpleProject/ChatDetailView.swift
@@ -31,17 +31,17 @@ struct ChatDetailView: View {
         VStack(spacing: 0) {
             HStack(spacing: 10) {
                 Image(systemName: "chevron.backward")
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(.body.weight(.semibold))
                     .foregroundStyle(Color.accentColor)
 
                 AvatarView(contact: conversation.contact, size: 36)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(conversation.contact.name)
-                        .font(.system(size: 16, weight: .semibold))
+                        .font(.body.weight(.semibold))
                         .lineLimit(1)
                     Text(presenceLine)
-                        .font(.system(size: 12))
+                        .font(.caption)
                         .foregroundStyle(conversation.isTyping ? Color.accentColor : Color.secondary)
                         .lineLimit(1)
                 }
@@ -51,7 +51,7 @@ struct ChatDetailView: View {
                 Image(systemName: "video")
                 Image(systemName: "phone")
             }
-            .font(.system(size: 17))
+            .font(.body)
             .foregroundStyle(Color.accentColor)
             .padding(.horizontal, 14)
             .padding(.vertical, 9)
@@ -158,19 +158,19 @@ struct ChatComposer: View {
             Divider()
             HStack(alignment: .bottom, spacing: 10) {
                 Image(systemName: "plus")
-                    .font(.system(size: 19, weight: .medium))
+                    .font(.title3.weight(.medium))
                     .foregroundStyle(Color.accentColor)
                     .frame(height: 36)
 
                 HStack(spacing: 8) {
                     Text(hasDraft ? draft : strings.messagePlaceholder)
-                        .font(.system(size: 16))
+                        .font(.body)
                         .foregroundStyle(hasDraft ? Color.primary : Color.secondary)
                         .lineLimit(4)
                         .fixedSize(horizontal: false, vertical: true)
                     Spacer(minLength: 4)
                     Image(systemName: "face.smiling")
-                        .font(.system(size: 17))
+                        .font(.body)
                         .foregroundStyle(.secondary)
                 }
                 .padding(.horizontal, 12)
@@ -179,7 +179,7 @@ struct ChatComposer: View {
                 .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
 
                 Image(systemName: hasDraft ? "arrow.up" : "mic.fill")
-                    .font(.system(size: hasDraft ? 16 : 17, weight: .semibold))
+                    .font(.body.weight(.semibold))
                     .foregroundStyle(hasDraft ? Color.white : Color.accentColor)
                     .frame(width: 36, height: 36)
                     .background(hasDraft ? Color.accentColor : Color.clear, in: Circle())

--- a/SimpleProject/ChatDetailView.swift
+++ b/SimpleProject/ChatDetailView.swift
@@ -1,0 +1,197 @@
+//
+//  ChatDetailView.swift
+//  SimpleProject
+//
+//  A single conversation: navigation bar with presence, the message transcript
+//  grouped by day, and the composer.
+//
+
+import SwiftUI
+
+struct ChatDetailView: View {
+    let conversation: Conversation
+    /// Text sitting in the composer, if any. Empty renders the idle state.
+    var draft: String = ""
+
+    @Environment(\.locale) private var locale
+    @Environment(\.strings) private var strings
+
+    var body: some View {
+        VStack(spacing: 0) {
+            navigationBar
+            transcript
+            ChatComposer(draft: draft)
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    // MARK: Navigation bar
+
+    private var navigationBar: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "chevron.backward")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                AvatarView(contact: conversation.contact, size: 36)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(conversation.contact.name)
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                    Text(presenceLine)
+                        .font(.system(size: 12))
+                        .foregroundStyle(conversation.isTyping ? Color.accentColor : Color.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "video")
+                Image(systemName: "phone")
+            }
+            .font(.system(size: 17))
+            .foregroundStyle(Color.accentColor)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+
+            Divider()
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private var presenceLine: String {
+        if conversation.isTyping {
+            return String(format: strings.typingFormat, firstName)
+        }
+        if conversation.contact.isGroup {
+            return String(format: strings.membersFormat, conversation.contact.groupMemberCount)
+        }
+        if conversation.contact.isOnline {
+            return strings.online
+        }
+        let lastSeen = conversation.lastMessage?.sentAt ?? ChatClock.now
+        return String(format: strings.lastSeenFormat, ChatClock.time(lastSeen, locale: locale))
+    }
+
+    private var firstName: String {
+        conversation.contact.name.split(separator: " ").first.map(String.init) ?? conversation.contact.name
+    }
+
+    // MARK: Transcript
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 6) {
+                ForEach(items) { item in
+                    switch item.kind {
+                    case .daySeparator(let label):
+                        DaySeparator(label: label)
+                    case .unreadDivider(let label):
+                        UnreadDivider(label: label)
+                    case .message(let message):
+                        MessageBubbleView(message: message)
+                    }
+                }
+
+                if conversation.isTyping {
+                    TypingIndicatorView()
+                        .padding(.top, 2)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    /// The transcript flattened into rows, with day separators inserted
+    /// whenever the calendar day changes.
+    private var items: [TranscriptItem] {
+        var result: [TranscriptItem] = []
+        var lastDay: Date?
+
+        for message in conversation.messages {
+            let day = ChatClock.calendar.startOfDay(for: message.sentAt)
+            if day != lastDay {
+                result.append(
+                    TranscriptItem(
+                        id: "day-\(day.timeIntervalSince1970)",
+                        kind: .daySeparator(ChatClock.daySeparator(message.sentAt, strings: strings, locale: locale))
+                    )
+                )
+                lastDay = day
+            }
+            if message.id == conversation.firstUnreadID {
+                result.append(
+                    TranscriptItem(id: "unread-\(message.id)", kind: .unreadDivider(strings.unreadDivider))
+                )
+            }
+            result.append(TranscriptItem(id: "message-\(message.id)", kind: .message(message)))
+        }
+
+        return result
+    }
+
+    struct TranscriptItem: Identifiable {
+        enum Kind {
+            case daySeparator(String)
+            case unreadDivider(String)
+            case message(Message)
+        }
+
+        let id: String
+        let kind: Kind
+    }
+}
+
+struct ChatComposer: View {
+    var draft: String = ""
+
+    @Environment(\.strings) private var strings
+
+    private var hasDraft: Bool { !draft.isEmpty }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(alignment: .bottom, spacing: 10) {
+                Image(systemName: "plus")
+                    .font(.system(size: 19, weight: .medium))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(height: 36)
+
+                HStack(spacing: 8) {
+                    Text(hasDraft ? draft : strings.messagePlaceholder)
+                        .font(.system(size: 16))
+                        .foregroundStyle(hasDraft ? Color.primary : Color.secondary)
+                        .lineLimit(4)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 4)
+                    Image(systemName: "face.smiling")
+                        .font(.system(size: 17))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .frame(minHeight: 36)
+                .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
+
+                Image(systemName: hasDraft ? "arrow.up" : "mic.fill")
+                    .font(.system(size: hasDraft ? 16 : 17, weight: .semibold))
+                    .foregroundStyle(hasDraft ? Color.white : Color.accentColor)
+                    .frame(width: 36, height: 36)
+                    .background(hasDraft ? Color.accentColor : Color.clear, in: Circle())
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+}
+
+#Preview {
+    ChatDetailView(conversation: SampleData.mayaThread(.english))
+        .chatLocale(Locale(identifier: "en_US"))
+}

--- a/SimpleProject/ChatModels.swift
+++ b/SimpleProject/ChatModels.swift
@@ -1,0 +1,193 @@
+//
+//  ChatModels.swift
+//  SimpleProject
+//
+//  Domain models for the chat app. Everything here is deterministic: dates are
+//  built from fixed components in UTC so snapshots never depend on the wall
+//  clock or the machine's time zone.
+//
+
+import SwiftUI
+
+enum MessageAuthor {
+    case me
+    case them
+}
+
+/// Delivery state, rendered as the little checkmarks on outgoing messages.
+enum DeliveryStatus {
+    case sending
+    case sent
+    case delivered
+    case read
+}
+
+enum MessageBody {
+    case text(String)
+    /// A photo attachment. The image is drawn as a gradient placeholder so the
+    /// project needs no binary assets.
+    case photo(caption: String?, tint: PaletteColor)
+    /// A voice note with a fixed waveform, so it renders identically every run.
+    case voice(seconds: Int, waveform: [CGFloat])
+    case file(name: String, size: String)
+}
+
+struct Reaction: Identifiable {
+    let id: Int
+    let emoji: String
+    let count: Int
+}
+
+struct Message: Identifiable {
+    let id: Int
+    let author: MessageAuthor
+    let body: MessageBody
+    let sentAt: Date
+    var status: DeliveryStatus = .read
+    var reactions: [Reaction] = []
+    /// A quoted message shown above the bubble.
+    var replyingTo: (author: String, text: String)?
+
+    var previewText: String {
+        switch body {
+        case .text(let text): return text
+        case .photo(let caption, _): return caption ?? ""
+        case .voice: return ""
+        case .file(let name, _): return name
+        }
+    }
+}
+
+/// Tints used for avatars and photo placeholders. Fixed set keeps colors stable
+/// across runs and readable in both color schemes.
+enum PaletteColor: CaseIterable {
+    case indigo, teal, orange, pink, green, purple
+
+    var gradient: LinearGradient {
+        LinearGradient(
+            colors: colors,
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var colors: [Color] {
+        switch self {
+        case .indigo: return [Color(red: 0.36, green: 0.42, blue: 0.94), Color(red: 0.24, green: 0.28, blue: 0.78)]
+        case .teal: return [Color(red: 0.18, green: 0.70, blue: 0.72), Color(red: 0.10, green: 0.52, blue: 0.60)]
+        case .orange: return [Color(red: 0.98, green: 0.62, blue: 0.24), Color(red: 0.92, green: 0.42, blue: 0.18)]
+        case .pink: return [Color(red: 0.95, green: 0.42, blue: 0.62), Color(red: 0.80, green: 0.25, blue: 0.52)]
+        case .green: return [Color(red: 0.30, green: 0.76, blue: 0.44), Color(red: 0.16, green: 0.58, blue: 0.34)]
+        case .purple: return [Color(red: 0.66, green: 0.42, blue: 0.94), Color(red: 0.48, green: 0.28, blue: 0.80)]
+        }
+    }
+}
+
+struct Contact: Identifiable {
+    let id: Int
+    let name: String
+    let initials: String
+    let tint: PaletteColor
+    var isOnline: Bool = false
+    /// Members of a group chat; empty for one-to-one conversations.
+    var groupMemberCount: Int = 0
+
+    var isGroup: Bool { groupMemberCount > 0 }
+}
+
+struct Conversation: Identifiable {
+    let id: Int
+    let contact: Contact
+    let messages: [Message]
+    var unreadCount: Int = 0
+    var isPinned: Bool = false
+    /// The message the "unread messages" divider is drawn above, if any.
+    var firstUnreadID: Int?
+    var isMuted: Bool = false
+    var isTyping: Bool = false
+    /// Overrides the row preview when the last message isn't plain text.
+    var previewOverride: String?
+
+    var lastMessage: Message? { messages.last }
+
+    var previewSymbol: String? {
+        switch lastMessage?.body {
+        case .photo: return "camera.fill"
+        case .voice: return "mic.fill"
+        case .file: return "doc.fill"
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Deterministic clock
+
+enum ChatClock {
+    static let timeZone = TimeZone(identifier: "UTC")!
+
+    static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    /// The "now" every screen is rendered against — Thursday, 12 June 2025, 16:20 UTC.
+    static let now = date(2025, 6, 12, 16, 20)
+
+    static func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date {
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: timeZone,
+            year: year, month: month, day: day, hour: hour, minute: minute
+        )
+        return components.date!
+    }
+
+    static func time(_ date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter.string(from: date)
+    }
+
+    static func weekday(_ date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.setLocalizedDateFormatFromTemplate("EEEE")
+        return formatter.string(from: date)
+    }
+
+    static func shortDate(_ date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.setLocalizedDateFormatFromTemplate("dMMM")
+        return formatter.string(from: date)
+    }
+
+    /// Row timestamps collapse to a time, "Yesterday", a weekday, or a date.
+    static func relativeStamp(_ date: Date, strings: Strings, locale: Locale) -> String {
+        let days = calendar.dateComponents([.day], from: calendar.startOfDay(for: date),
+                                           to: calendar.startOfDay(for: now)).day ?? 0
+        switch days {
+        case 0: return time(date, locale: locale)
+        case 1: return strings.yesterday
+        case 2...6: return weekday(date, locale: locale)
+        default: return shortDate(date, locale: locale)
+        }
+    }
+
+    static func daySeparator(_ date: Date, strings: Strings, locale: Locale) -> String {
+        let days = calendar.dateComponents([.day], from: calendar.startOfDay(for: date),
+                                           to: calendar.startOfDay(for: now)).day ?? 0
+        switch days {
+        case 0: return strings.today
+        case 1: return strings.yesterday
+        case 2...6: return weekday(date, locale: locale)
+        default: return shortDate(date, locale: locale)
+        }
+    }
+}

--- a/SimpleProject/ChatSampleData.swift
+++ b/SimpleProject/ChatSampleData.swift
@@ -1,0 +1,233 @@
+//
+//  ChatSampleData.swift
+//  SimpleProject
+//
+//  Fixture data for previews and snapshot tests. Built from `Strings` so every
+//  screen can be rendered in any supported language.
+//
+
+import SwiftUI
+
+enum SampleData {
+
+    // MARK: Contacts
+
+    static func maya(_ s: Strings) -> Contact {
+        Contact(id: 1, name: "Maya Ferreira", initials: "MF", tint: .indigo, isOnline: true)
+    }
+
+    static func devTeam(_ s: Strings) -> Contact {
+        Contact(id: 2, name: s.groupDevTeam, initials: "DT", tint: .teal, groupMemberCount: 8)
+    }
+
+    static func priya(_ s: Strings) -> Contact {
+        Contact(id: 3, name: "Priya Raman", initials: "PR", tint: .pink, isOnline: true)
+    }
+
+    static func marco(_ s: Strings) -> Contact {
+        Contact(id: 4, name: "Marco Bianchi", initials: "MB", tint: .orange)
+    }
+
+    static func family(_ s: Strings) -> Contact {
+        Contact(id: 5, name: s.groupFamily, initials: "F", tint: .green, groupMemberCount: 5)
+    }
+
+    static func sam(_ s: Strings) -> Contact {
+        Contact(id: 6, name: "Sam Okafor", initials: "SO", tint: .purple)
+    }
+
+    static func jonas(_ s: Strings) -> Contact {
+        Contact(id: 7, name: "Jonas Weber", initials: "JW", tint: .teal)
+    }
+
+    static func alerts(_ s: Strings) -> Contact {
+        Contact(id: 8, name: "Deploy Alerts", initials: "DA", tint: .indigo)
+    }
+
+    // MARK: Threads
+
+    private static let waveform: [CGFloat] = [
+        0.25, 0.45, 0.70, 0.95, 0.60, 0.35, 0.55, 0.80, 1.00, 0.75,
+        0.40, 0.30, 0.65, 0.85, 0.50, 0.30, 0.45, 0.70, 0.40, 0.20,
+    ]
+
+    /// The main thread used by most chat-detail snapshots. Spans two days so the
+    /// "Yesterday" / "Today" separators both appear.
+    static func mayaThread(_ s: Strings) -> Conversation {
+        let yesterday = { (h: Int, m: Int) in ChatClock.date(2025, 6, 11, h, m) }
+        let today = { (h: Int, m: Int) in ChatClock.date(2025, 6, 12, h, m) }
+
+        let messages: [Message] = [
+            Message(
+                id: 1, author: .them,
+                body: .voice(seconds: 35, waveform: waveform),
+                sentAt: yesterday(17, 20)
+            ),
+            Message(
+                id: 2, author: .me,
+                body: .text(s.threadThanks),
+                sentAt: yesterday(17, 24),
+                status: .read
+            ),
+            Message(
+                id: 3, author: .them,
+                body: .text(s.threadHello),
+                sentAt: today(9, 12)
+            ),
+            Message(
+                id: 4, author: .me,
+                body: .text(s.threadReply),
+                sentAt: today(9, 15),
+                status: .read
+            ),
+            Message(
+                id: 5, author: .them,
+                body: .photo(caption: s.threadPhotoCaption, tint: .purple),
+                sentAt: today(9, 41),
+                reactions: [Reaction(id: 1, emoji: "🔥", count: 2)]
+            ),
+            Message(
+                id: 6, author: .me,
+                body: .text(s.threadShipIt),
+                sentAt: today(9, 44),
+                status: .read
+            ),
+            Message(
+                id: 7, author: .them,
+                body: .text(s.threadOneMore),
+                sentAt: today(16, 2)
+            ),
+            Message(
+                id: 8, author: .them,
+                body: .text(s.threadBadge),
+                sentAt: today(16, 3)
+            ),
+            Message(
+                id: 9, author: .me,
+                body: .text(s.threadAlreadyDone),
+                sentAt: today(16, 5),
+                status: .delivered,
+                replyingTo: (author: "Maya Ferreira", text: s.threadBadge)
+            ),
+            Message(
+                id: 10, author: .them,
+                body: .file(name: "Design-System-v4.pdf", size: "2.4 MB"),
+                sentAt: today(16, 12)
+            ),
+        ]
+
+        return Conversation(
+            id: 1,
+            contact: maya(s),
+            messages: messages,
+            unreadCount: 2,
+            isPinned: true,
+            firstUnreadID: 7
+        )
+    }
+
+    /// Same participants, mid-conversation: the other side is typing and the
+    /// outgoing message is still in flight.
+    static func mayaThreadTyping(_ s: Strings) -> Conversation {
+        var conversation = mayaThread(s)
+        var messages = Array(conversation.messages.prefix(9))
+        messages[8].status = .sending
+        conversation = Conversation(
+            id: 1,
+            contact: maya(s),
+            messages: messages,
+            unreadCount: 0,
+            isPinned: true,
+            isTyping: true
+        )
+        return conversation
+    }
+
+    /// A brand-new thread — one message, nothing else.
+    static func freshThread(_ s: Strings) -> Conversation {
+        Conversation(
+            id: 9,
+            contact: jonas(s),
+            messages: [
+                Message(
+                    id: 1, author: .me,
+                    body: .text(s.threadHello),
+                    sentAt: ChatClock.date(2025, 6, 12, 16, 18),
+                    status: .sent
+                )
+            ]
+        )
+    }
+
+    // MARK: Conversation list
+
+    static func conversations(_ s: Strings) -> [Conversation] {
+        let thread = mayaThread(s)
+
+        return [
+            thread,
+            Conversation(
+                id: 2,
+                contact: devTeam(s),
+                messages: [
+                    Message(id: 1, author: .them, body: .text(s.previewDevTeam),
+                            sentAt: ChatClock.date(2025, 6, 12, 15, 48))
+                ],
+                unreadCount: 12,
+                isMuted: true
+            ),
+            Conversation(
+                id: 3,
+                contact: priya(s),
+                messages: [
+                    Message(id: 1, author: .me, body: .text(s.previewPriya),
+                            sentAt: ChatClock.date(2025, 6, 12, 14, 2), status: .read)
+                ],
+                isTyping: true
+            ),
+            Conversation(
+                id: 4,
+                contact: marco(s),
+                messages: [
+                    Message(id: 1, author: .them, body: .voice(seconds: 12, waveform: waveform),
+                            sentAt: ChatClock.date(2025, 6, 12, 11, 27))
+                ],
+                unreadCount: 1,
+                previewOverride: s.voiceMessage
+            ),
+            Conversation(
+                id: 5,
+                contact: family(s),
+                messages: [
+                    Message(id: 1, author: .them, body: .text(s.previewFamily),
+                            sentAt: ChatClock.date(2025, 6, 11, 19, 5))
+                ],
+                isMuted: true
+            ),
+            Conversation(
+                id: 6,
+                contact: sam(s),
+                messages: [
+                    Message(id: 1, author: .me, body: .text(s.previewSam),
+                            sentAt: ChatClock.date(2025, 6, 10, 16, 40), status: .delivered)
+                ]
+            ),
+            Conversation(
+                id: 7,
+                contact: jonas(s),
+                messages: [
+                    Message(id: 1, author: .them, body: .text(s.previewJonas),
+                            sentAt: ChatClock.date(2025, 6, 8, 10, 15))
+                ]
+            ),
+            Conversation(
+                id: 8,
+                contact: alerts(s),
+                messages: [
+                    Message(id: 1, author: .them, body: .text(s.previewAlerts),
+                            sentAt: ChatClock.date(2025, 5, 29, 8, 3))
+                ]
+            ),
+        ]
+    }
+}

--- a/SimpleProject/ContentView.swift
+++ b/SimpleProject/ContentView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.locale) private var locale
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        ConversationListView(conversations: SampleData.conversations(strings))
+            .environment(\.strings, strings)
+    }
+
+    private var strings: Strings {
+        Strings.forLocale(locale)
     }
 }
 

--- a/SimpleProject/ConversationListView.swift
+++ b/SimpleProject/ConversationListView.swift
@@ -1,0 +1,240 @@
+//
+//  ConversationListView.swift
+//  SimpleProject
+//
+//  The inbox: search field, pinned + recent conversations, tab bar.
+//
+
+import SwiftUI
+
+struct ConversationListView: View {
+    let conversations: [Conversation]
+
+    @Environment(\.locale) private var locale
+    @Environment(\.strings) private var strings
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            if conversations.isEmpty {
+                ChatEmptyStateView()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(conversations) { conversation in
+                            ConversationRow(conversation: conversation)
+                            Divider().padding(.leading, 80)
+                        }
+                    }
+                }
+            }
+
+            ChatTabBar(unreadCount: totalUnread)
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private var totalUnread: Int {
+        conversations.reduce(0) { $0 + $1.unreadCount }
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Text(strings.appTitle)
+                    .font(.largeTitle.bold())
+                Spacer()
+                circleButton("camera")
+                circleButton("square.and.pencil")
+            }
+
+            HStack(spacing: 7) {
+                Image(systemName: "magnifyingglass")
+                Text(strings.search)
+                Spacer(minLength: 0)
+            }
+            .font(.system(size: 16))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+    }
+
+    private func circleButton(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(Color.accentColor)
+            .frame(width: 34, height: 34)
+            .background(Color(uiColor: .secondarySystemBackground), in: Circle())
+    }
+}
+
+struct ConversationRow: View {
+    let conversation: Conversation
+
+    @Environment(\.locale) private var locale
+    @Environment(\.strings) private var strings
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            AvatarView(contact: conversation.contact)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(conversation.contact.name)
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                    if conversation.isMuted {
+                        Image(systemName: "bell.slash.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: 4)
+                    if let last = conversation.lastMessage {
+                        Text(ChatClock.relativeStamp(last.sentAt, strings: strings, locale: locale))
+                            .font(.system(size: 13))
+                            .foregroundStyle(conversation.unreadCount > 0 && !conversation.isMuted
+                                             ? Color.accentColor : Color.secondary)
+                    }
+                }
+
+                HStack(alignment: .top, spacing: 6) {
+                    preview
+                    Spacer(minLength: 4)
+                    trailingAccessory
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var preview: some View {
+        if conversation.isTyping {
+            Text(String(format: strings.typingFormat, firstName))
+                .font(.system(size: 15))
+                .foregroundStyle(Color.accentColor)
+                .lineLimit(1)
+        } else {
+            HStack(spacing: 4) {
+                if conversation.lastMessage?.author == .me, let status = conversation.lastMessage?.status {
+                    DeliveryTicksView(status: status, tint: .secondary)
+                }
+                if let symbol = conversation.previewSymbol {
+                    Image(systemName: symbol)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                Text(conversation.previewOverride ?? conversation.lastMessage?.previewText ?? "")
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var trailingAccessory: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            if conversation.unreadCount > 0 {
+                UnreadBadge(count: conversation.unreadCount, muted: conversation.isMuted)
+            } else if conversation.isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 12))
+                    .rotationEffect(.degrees(45))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var firstName: String {
+        conversation.contact.name.split(separator: " ").first.map(String.init) ?? conversation.contact.name
+    }
+}
+
+struct ChatEmptyStateView: View {
+    @Environment(\.strings) private var strings
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 52, weight: .thin))
+                .foregroundStyle(Color.accentColor.opacity(0.7))
+            Text(strings.emptyTitle)
+                .font(.title3.weight(.semibold))
+            Text(strings.emptyBody)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 260)
+            Text(strings.emptyAction)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 22)
+                .padding(.vertical, 12)
+                .background(Color.accentColor, in: Capsule())
+                .padding(.top, 4)
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct ChatTabBar: View {
+    var unreadCount: Int = 0
+
+    @Environment(\.strings) private var strings
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(alignment: .top, spacing: 0) {
+                item("bubble.left.and.bubble.right.fill", strings.tabChats, selected: true, badge: unreadCount)
+                item("phone.fill", strings.tabCalls, selected: false, badge: 0)
+                item("gearshape.fill", strings.tabSettings, selected: false, badge: 0)
+            }
+            .padding(.top, 8)
+            .padding(.bottom, 4)
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private func item(_ symbol: String, _ title: String, selected: Bool, badge: Int) -> some View {
+        VStack(spacing: 3) {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: symbol)
+                    .font(.system(size: 19))
+                    .frame(width: 34, height: 24)
+                if badge > 0 {
+                    Text("\(badge)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 4)
+                        .frame(minWidth: 16, minHeight: 16)
+                        .background(Color.red, in: Capsule())
+                        .offset(x: 4, y: -5)
+                }
+            }
+            Text(title)
+                .font(.system(size: 10, weight: .medium))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .foregroundStyle(selected ? Color.accentColor : Color.secondary)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview {
+    ConversationListView(conversations: SampleData.conversations(.english))
+        .chatLocale(Locale(identifier: "en_US"))
+}

--- a/SimpleProject/ConversationListView.swift
+++ b/SimpleProject/ConversationListView.swift
@@ -54,7 +54,7 @@ struct ConversationListView: View {
                 Text(strings.search)
                 Spacer(minLength: 0)
             }
-            .font(.system(size: 16))
+            .font(.body)
             .foregroundStyle(.secondary)
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
@@ -67,7 +67,7 @@ struct ConversationListView: View {
 
     private func circleButton(_ systemName: String) -> some View {
         Image(systemName: systemName)
-            .font(.system(size: 16, weight: .semibold))
+            .font(.body.weight(.semibold))
             .foregroundStyle(Color.accentColor)
             .frame(width: 34, height: 34)
             .background(Color(uiColor: .secondarySystemBackground), in: Circle())
@@ -87,17 +87,17 @@ struct ConversationRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
                     Text(conversation.contact.name)
-                        .font(.system(size: 16, weight: .semibold))
+                        .font(.body.weight(.semibold))
                         .lineLimit(1)
                     if conversation.isMuted {
                         Image(systemName: "bell.slash.fill")
-                            .font(.system(size: 11))
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                     Spacer(minLength: 4)
                     if let last = conversation.lastMessage {
                         Text(ChatClock.relativeStamp(last.sentAt, strings: strings, locale: locale))
-                            .font(.system(size: 13))
+                            .font(.footnote)
                             .foregroundStyle(conversation.unreadCount > 0 && !conversation.isMuted
                                              ? Color.accentColor : Color.secondary)
                     }
@@ -119,7 +119,7 @@ struct ConversationRow: View {
     private var preview: some View {
         if conversation.isTyping {
             Text(String(format: strings.typingFormat, firstName))
-                .font(.system(size: 15))
+                .font(.subheadline)
                 .foregroundStyle(Color.accentColor)
                 .lineLimit(1)
         } else {
@@ -129,11 +129,11 @@ struct ConversationRow: View {
                 }
                 if let symbol = conversation.previewSymbol {
                     Image(systemName: symbol)
-                        .font(.system(size: 12))
+                        .font(.caption)
                         .foregroundStyle(.secondary)
                 }
                 Text(conversation.previewOverride ?? conversation.lastMessage?.previewText ?? "")
-                    .font(.system(size: 15))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
@@ -147,7 +147,7 @@ struct ConversationRow: View {
                 UnreadBadge(count: conversation.unreadCount, muted: conversation.isMuted)
             } else if conversation.isPinned {
                 Image(systemName: "pin.fill")
-                    .font(.system(size: 12))
+                    .font(.caption)
                     .rotationEffect(.degrees(45))
                     .foregroundStyle(.secondary)
             }
@@ -176,7 +176,7 @@ struct ChatEmptyStateView: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 260)
             Text(strings.emptyAction)
-                .font(.system(size: 16, weight: .semibold))
+                .font(.body.weight(.semibold))
                 .foregroundStyle(.white)
                 .padding(.horizontal, 22)
                 .padding(.vertical, 12)
@@ -212,11 +212,11 @@ struct ChatTabBar: View {
         VStack(spacing: 3) {
             ZStack(alignment: .topTrailing) {
                 Image(systemName: symbol)
-                    .font(.system(size: 19))
-                    .frame(width: 34, height: 24)
+                    .font(.title3)
+                    .frame(minWidth: 34, minHeight: 24)
                 if badge > 0 {
                     Text("\(badge)")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.caption2.weight(.bold))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 4)
                         .frame(minWidth: 16, minHeight: 16)
@@ -225,7 +225,7 @@ struct ChatTabBar: View {
                 }
             }
             Text(title)
-                .font(.system(size: 10, weight: .medium))
+                .font(.caption2.weight(.medium))
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
         }

--- a/SimpleProject/MessageBubbleView.swift
+++ b/SimpleProject/MessageBubbleView.swift
@@ -1,0 +1,214 @@
+//
+//  MessageBubbleView.swift
+//  SimpleProject
+//
+//  A single message row: quote, body (text / photo / voice note / file),
+//  timestamp, delivery ticks and reactions.
+//
+
+import SwiftUI
+
+struct MessageBubbleView: View {
+    let message: Message
+
+    @Environment(\.locale) private var locale
+    @Environment(\.strings) private var strings
+
+    private var isMine: Bool { message.author == .me }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if isMine { Spacer(minLength: 56) }
+
+            VStack(alignment: isMine ? .trailing : .leading, spacing: -8) {
+                bubble
+                if !message.reactions.isEmpty {
+                    reactions
+                        .padding(isMine ? .trailing : .leading, 12)
+                        .zIndex(1)
+                }
+            }
+
+            if !isMine { Spacer(minLength: 56) }
+        }
+        .padding(.bottom, message.reactions.isEmpty ? 0 : 8)
+    }
+
+    // MARK: Bubble
+
+    private var bubble: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let quote = message.replyingTo {
+                quoteView(author: quote.author, text: quote.text)
+            }
+
+            switch message.body {
+            case .text(let text):
+                Text(text)
+                    .font(.system(size: 16))
+                    .foregroundStyle(isMine ? Color.white : Color.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+            case .photo(let caption, let tint):
+                photoView(tint: tint)
+                if let caption {
+                    Text(caption)
+                        .font(.system(size: 16))
+                        .foregroundStyle(isMine ? Color.white : Color.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+            case .voice(let seconds, let waveform):
+                voiceView(seconds: seconds, waveform: waveform)
+
+            case .file(let name, let size):
+                fileView(name: name, size: size)
+            }
+
+            footer
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(bubbleBackground)
+        .clipShape(bubbleShape)
+    }
+
+    private var bubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            cornerRadii: .init(
+                topLeading: 18,
+                bottomLeading: isMine ? 18 : 5,
+                bottomTrailing: isMine ? 5 : 18,
+                topTrailing: 18
+            )
+        )
+    }
+
+    @ViewBuilder
+    private var bubbleBackground: some View {
+        if isMine {
+            LinearGradient(
+                colors: [Color(red: 0.20, green: 0.52, blue: 0.98), Color(red: 0.13, green: 0.38, blue: 0.92)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        } else {
+            Color(uiColor: .secondarySystemBackground)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 4) {
+            Text(ChatClock.time(message.sentAt, locale: locale))
+                .font(.system(size: 11))
+                .foregroundStyle(isMine ? Color.white.opacity(0.75) : Color.secondary)
+            if isMine {
+                DeliveryTicksView(status: message.status)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    // MARK: Bodies
+
+    private func quoteView(author: String, text: String) -> some View {
+        HStack(spacing: 8) {
+            Capsule()
+                .fill(isMine ? Color.white.opacity(0.8) : Color.accentColor)
+                .frame(width: 3)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(author)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(isMine ? Color.white : Color.accentColor)
+                Text(text)
+                    .font(.system(size: 13))
+                    .lineLimit(1)
+                    .foregroundStyle(isMine ? Color.white.opacity(0.85) : Color.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .frame(maxWidth: 230, alignment: .leading)
+        .background(
+            (isMine ? Color.white.opacity(0.18) : Color.primary.opacity(0.06)),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
+    }
+
+    private func photoView(tint: PaletteColor) -> some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(tint.gradient)
+            .frame(width: 214, height: 148)
+            .overlay {
+                Image(systemName: "photo")
+                    .font(.system(size: 34, weight: .light))
+                    .foregroundStyle(.white.opacity(0.85))
+            }
+            .accessibilityLabel(strings.photo)
+    }
+
+    private func voiceView(seconds: Int, waveform: [CGFloat]) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "play.fill")
+                .font(.system(size: 13))
+                .foregroundStyle(isMine ? Color.white : Color.accentColor)
+                .frame(width: 30, height: 30)
+                .background(
+                    (isMine ? Color.white.opacity(0.22) : Color.accentColor.opacity(0.15)),
+                    in: Circle()
+                )
+
+            WaveformView(
+                samples: waveform,
+                tint: isMine ? Color.white.opacity(0.85) : Color.accentColor.opacity(0.7)
+            )
+
+            Text(String(format: "0:%02d", seconds))
+                .font(.system(size: 12).monospacedDigit())
+                .foregroundStyle(isMine ? Color.white.opacity(0.8) : Color.secondary)
+        }
+        .accessibilityLabel(strings.voiceMessage)
+    }
+
+    private func fileView(name: String, size: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc.fill")
+                .font(.system(size: 17))
+                .foregroundStyle(isMine ? Color.white : Color.accentColor)
+                .frame(width: 38, height: 38)
+                .background(
+                    (isMine ? Color.white.opacity(0.22) : Color.accentColor.opacity(0.15)),
+                    in: RoundedRectangle(cornerRadius: 9)
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.system(size: 15, weight: .medium))
+                    .lineLimit(1)
+                    .foregroundStyle(isMine ? Color.white : Color.primary)
+                Text(size)
+                    .font(.system(size: 12))
+                    .foregroundStyle(isMine ? Color.white.opacity(0.75) : Color.secondary)
+            }
+        }
+    }
+
+    private var reactions: some View {
+        HStack(spacing: 4) {
+            ForEach(message.reactions) { reaction in
+                HStack(spacing: 3) {
+                    Text(reaction.emoji).font(.system(size: 12))
+                    if reaction.count > 1 {
+                        Text("\(reaction.count)")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Color(uiColor: .systemBackground), in: Capsule())
+                .overlay(Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 1))
+            }
+        }
+    }
+}

--- a/SimpleProject/MessageBubbleView.swift
+++ b/SimpleProject/MessageBubbleView.swift
@@ -45,7 +45,7 @@ struct MessageBubbleView: View {
             switch message.body {
             case .text(let text):
                 Text(text)
-                    .font(.system(size: 16))
+                    .font(.body)
                     .foregroundStyle(isMine ? Color.white : Color.primary)
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -53,7 +53,7 @@ struct MessageBubbleView: View {
                 photoView(tint: tint)
                 if let caption {
                     Text(caption)
-                        .font(.system(size: 16))
+                        .font(.body)
                         .foregroundStyle(isMine ? Color.white : Color.primary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -100,7 +100,7 @@ struct MessageBubbleView: View {
     private var footer: some View {
         HStack(spacing: 4) {
             Text(ChatClock.time(message.sentAt, locale: locale))
-                .font(.system(size: 11))
+                .font(.caption2)
                 .foregroundStyle(isMine ? Color.white.opacity(0.75) : Color.secondary)
             if isMine {
                 DeliveryTicksView(status: message.status)
@@ -118,10 +118,10 @@ struct MessageBubbleView: View {
                 .frame(width: 3)
             VStack(alignment: .leading, spacing: 1) {
                 Text(author)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(isMine ? Color.white : Color.accentColor)
                 Text(text)
-                    .font(.system(size: 13))
+                    .font(.footnote)
                     .lineLimit(1)
                     .foregroundStyle(isMine ? Color.white.opacity(0.85) : Color.secondary)
             }
@@ -164,7 +164,7 @@ struct MessageBubbleView: View {
             )
 
             Text(String(format: "0:%02d", seconds))
-                .font(.system(size: 12).monospacedDigit())
+                .font(.caption.monospacedDigit())
                 .foregroundStyle(isMine ? Color.white.opacity(0.8) : Color.secondary)
         }
         .accessibilityLabel(strings.voiceMessage)
@@ -183,11 +183,11 @@ struct MessageBubbleView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(name)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                     .lineLimit(1)
                     .foregroundStyle(isMine ? Color.white : Color.primary)
                 Text(size)
-                    .font(.system(size: 12))
+                    .font(.caption)
                     .foregroundStyle(isMine ? Color.white.opacity(0.75) : Color.secondary)
             }
         }
@@ -197,10 +197,10 @@ struct MessageBubbleView: View {
         HStack(spacing: 4) {
             ForEach(message.reactions) { reaction in
                 HStack(spacing: 3) {
-                    Text(reaction.emoji).font(.system(size: 12))
+                    Text(reaction.emoji).font(.caption)
                     if reaction.count > 1 {
                         Text("\(reaction.count)")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.caption2.weight(.medium))
                             .foregroundStyle(.secondary)
                     }
                 }

--- a/SimpleProject/Strings.swift
+++ b/SimpleProject/Strings.swift
@@ -1,0 +1,291 @@
+//
+//  Strings.swift
+//  SimpleProject
+//
+//  Translations for the chat app.
+//
+//  These live in Swift rather than a `.strings` catalog on purpose: snapshot
+//  tests can then pick a language by setting `\.locale` on the view under test,
+//  and the rendered text never depends on the simulator's language settings or
+//  on which resources happened to be copied into the test host bundle.
+//
+
+import SwiftUI
+
+struct Strings {
+    // Chrome
+    let appTitle: String
+    let search: String
+    let tabChats: String
+    let tabCalls: String
+    let tabSettings: String
+
+    // Presence
+    let online: String
+    /// Formatted with the contact's first name.
+    let typingFormat: String
+    /// Formatted with a time, e.g. "last seen at 09:41".
+    let lastSeenFormat: String
+    /// Formatted with a member count.
+    let membersFormat: String
+
+    // Dates
+    let today: String
+    let yesterday: String
+
+    // Composer + attachments
+    let messagePlaceholder: String
+    let photo: String
+    let voiceMessage: String
+    let unreadDivider: String
+
+    // Empty state
+    let emptyTitle: String
+    let emptyBody: String
+    let emptyAction: String
+
+    // Group names (people's names are left untranslated)
+    let groupDevTeam: String
+    let groupFamily: String
+
+    // Conversation list previews
+    let previewDevTeam: String
+    let previewPriya: String
+    let previewFamily: String
+    let previewSam: String
+    let previewJonas: String
+    let previewAlerts: String
+
+    // The thread rendered by the chat detail snapshots
+    let threadHello: String
+    let threadReply: String
+    let threadPhotoCaption: String
+    let threadShipIt: String
+    let threadOneMore: String
+    let threadBadge: String
+    let threadAlreadyDone: String
+    let threadThanks: String
+
+    /// Picks the translation for a locale, falling back to English.
+    static func forLocale(_ locale: Locale) -> Strings {
+        switch locale.identifier.prefix(2) {
+        case "es": return .spanish
+        case "ja": return .japanese
+        case "de": return .german
+        case "ar": return .arabic
+        default: return .english
+        }
+    }
+}
+
+extension Strings {
+    static let english = Strings(
+        appTitle: "Messages",
+        search: "Search",
+        tabChats: "Chats",
+        tabCalls: "Calls",
+        tabSettings: "Settings",
+        online: "online",
+        typingFormat: "%@ is typing…",
+        lastSeenFormat: "last seen at %@",
+        membersFormat: "%d members",
+        today: "Today",
+        yesterday: "Yesterday",
+        messagePlaceholder: "Message",
+        photo: "Photo",
+        voiceMessage: "Voice message",
+        unreadDivider: "Unread messages",
+        emptyTitle: "No conversations yet",
+        emptyBody: "Start a new chat and it will show up right here.",
+        emptyAction: "Start a chat",
+        groupDevTeam: "Dev Team",
+        groupFamily: "Family",
+        previewDevTeam: "Ana: build 412 is green ✅",
+        previewPriya: "See you at six!",
+        previewFamily: "Mum: don't forget Sunday lunch",
+        previewSam: "Invoice is on its way over",
+        previewJonas: "Perfect, thanks for the quick turnaround",
+        previewAlerts: "Your deploy finished in 3m 12s",
+        threadHello: "Morning! Did you get a chance to look at the new mockups?",
+        threadReply: "Just opened them. The empty state reads so much better now 🙌",
+        threadPhotoCaption: "Went with the softer gradient in the end",
+        threadShipIt: "Ship it. I'll re-record the snapshots tonight.",
+        threadOneMore: "Perfect. One more thing —",
+        threadBadge: "Could the unread badge use the accent colour instead?",
+        threadAlreadyDone: "Already done, pushing the change now.",
+        threadThanks: "You're a star, thank you!"
+    )
+
+    static let spanish = Strings(
+        appTitle: "Mensajes",
+        search: "Buscar",
+        tabChats: "Chats",
+        tabCalls: "Llamadas",
+        tabSettings: "Ajustes",
+        online: "en línea",
+        typingFormat: "%@ está escribiendo…",
+        lastSeenFormat: "última vez a las %@",
+        membersFormat: "%d miembros",
+        today: "Hoy",
+        yesterday: "Ayer",
+        messagePlaceholder: "Mensaje",
+        photo: "Foto",
+        voiceMessage: "Mensaje de voz",
+        unreadDivider: "Mensajes sin leer",
+        emptyTitle: "Aún no hay conversaciones",
+        emptyBody: "Empieza un chat nuevo y aparecerá aquí mismo.",
+        emptyAction: "Empezar un chat",
+        groupDevTeam: "Equipo de desarrollo",
+        groupFamily: "Familia",
+        previewDevTeam: "Ana: la compilación 412 está en verde ✅",
+        previewPriya: "¡Nos vemos a las seis!",
+        previewFamily: "Mamá: no olvides la comida del domingo",
+        previewSam: "La factura ya va en camino",
+        previewJonas: "Perfecto, gracias por la rapidez",
+        previewAlerts: "Tu despliegue terminó en 3 min 12 s",
+        threadHello: "¡Buenos días! ¿Pudiste ver los nuevos diseños?",
+        threadReply: "Acabo de abrirlos. El estado vacío se entiende mucho mejor 🙌",
+        threadPhotoCaption: "Al final nos quedamos con el degradado más suave",
+        threadShipIt: "Adelante. Vuelvo a grabar las capturas esta noche.",
+        threadOneMore: "Perfecto. Una cosa más —",
+        threadBadge: "¿La insignia de no leídos podría usar el color de acento?",
+        threadAlreadyDone: "Ya está hecho, subo el cambio ahora.",
+        threadThanks: "¡Eres genial, muchas gracias!"
+    )
+
+    static let german = Strings(
+        appTitle: "Nachrichten",
+        search: "Suchen",
+        tabChats: "Chats",
+        tabCalls: "Anrufe",
+        tabSettings: "Einstellungen",
+        online: "online",
+        typingFormat: "%@ schreibt gerade…",
+        lastSeenFormat: "zuletzt gesehen um %@",
+        membersFormat: "%d Mitglieder",
+        today: "Heute",
+        yesterday: "Gestern",
+        messagePlaceholder: "Nachricht",
+        photo: "Foto",
+        voiceMessage: "Sprachnachricht",
+        unreadDivider: "Ungelesene Nachrichten",
+        emptyTitle: "Noch keine Unterhaltungen",
+        emptyBody: "Starte einen neuen Chat – er erscheint dann genau hier.",
+        emptyAction: "Chat starten",
+        groupDevTeam: "Entwicklungsteam",
+        groupFamily: "Familie",
+        previewDevTeam: "Ana: Build 412 ist grün ✅",
+        previewPriya: "Bis um sechs!",
+        previewFamily: "Mama: vergiss das Sonntagsessen nicht",
+        previewSam: "Die Rechnung ist unterwegs",
+        previewJonas: "Perfekt, danke für die schnelle Umsetzung",
+        previewAlerts: "Dein Deployment lief in 3 Min. 12 Sek. durch",
+        threadHello: "Guten Morgen! Konntest du dir die neuen Entwürfe schon ansehen?",
+        threadReply: "Gerade geöffnet. Der leere Zustand liest sich jetzt viel besser 🙌",
+        threadPhotoCaption: "Am Ende ist es doch der weichere Verlauf geworden",
+        threadShipIt: "Dann raus damit. Ich nehme die Snapshots heute Abend neu auf.",
+        threadOneMore: "Super. Noch eine Sache —",
+        threadBadge: "Könnte das Ungelesen-Abzeichen die Akzentfarbe verwenden?",
+        threadAlreadyDone: "Schon erledigt, ich pushe die Änderung gerade.",
+        threadThanks: "Du bist die Beste, vielen Dank!"
+    )
+
+    static let japanese = Strings(
+        appTitle: "メッセージ",
+        search: "検索",
+        tabChats: "チャット",
+        tabCalls: "通話",
+        tabSettings: "設定",
+        online: "オンライン",
+        typingFormat: "%@さんが入力中…",
+        lastSeenFormat: "最終接続 %@",
+        membersFormat: "メンバー%d人",
+        today: "今日",
+        yesterday: "昨日",
+        messagePlaceholder: "メッセージ",
+        photo: "写真",
+        voiceMessage: "ボイスメッセージ",
+        unreadDivider: "未読メッセージ",
+        emptyTitle: "まだ会話がありません",
+        emptyBody: "新しいチャットを始めると、ここに表示されます。",
+        emptyAction: "チャットを始める",
+        groupDevTeam: "開発チーム",
+        groupFamily: "家族",
+        previewDevTeam: "Ana: ビルド412はグリーンです ✅",
+        previewPriya: "6時にね！",
+        previewFamily: "母: 日曜のランチを忘れないでね",
+        previewSam: "請求書をこれから送ります",
+        previewJonas: "完璧です、迅速な対応ありがとう",
+        previewAlerts: "デプロイが3分12秒で完了しました",
+        threadHello: "おはよう！新しいモックアップは見てもらえた？",
+        threadReply: "今開いたところ。空の状態がすごく分かりやすくなったね 🙌",
+        threadPhotoCaption: "結局やわらかいグラデーションにしました",
+        threadShipIt: "これでいこう。今夜スナップショットを撮り直すね。",
+        threadOneMore: "完璧。もうひとつだけ —",
+        threadBadge: "未読バッジをアクセントカラーにできますか？",
+        threadAlreadyDone: "もう対応済みです。今プッシュします。",
+        threadThanks: "さすがです、ありがとう！"
+    )
+
+    static let arabic = Strings(
+        appTitle: "الرسائل",
+        search: "بحث",
+        tabChats: "المحادثات",
+        tabCalls: "المكالمات",
+        tabSettings: "الإعدادات",
+        online: "متصل الآن",
+        typingFormat: "%@ يكتب الآن…",
+        lastSeenFormat: "آخر ظهور %@",
+        membersFormat: "%d أعضاء",
+        today: "اليوم",
+        yesterday: "أمس",
+        messagePlaceholder: "رسالة",
+        photo: "صورة",
+        voiceMessage: "رسالة صوتية",
+        unreadDivider: "رسائل غير مقروءة",
+        emptyTitle: "لا توجد محادثات بعد",
+        emptyBody: "ابدأ محادثة جديدة وستظهر هنا مباشرة.",
+        emptyAction: "بدء محادثة",
+        groupDevTeam: "فريق التطوير",
+        groupFamily: "العائلة",
+        previewDevTeam: "Ana: الإصدار 412 ناجح ✅",
+        previewPriya: "أراك في السادسة!",
+        previewFamily: "أمي: لا تنسَ غداء الأحد",
+        previewSam: "الفاتورة في طريقها إليك",
+        previewJonas: "ممتاز، شكرًا على السرعة",
+        previewAlerts: "اكتمل النشر خلال 3 د 12 ث",
+        threadHello: "صباح الخير! هل تمكّنت من مراجعة التصاميم الجديدة؟",
+        threadReply: "فتحتها للتو. حالة الفراغ أصبحت أوضح بكثير 🙌",
+        threadPhotoCaption: "اخترنا في النهاية التدرّج اللوني الأنعم",
+        threadShipIt: "لننشرها إذًا. سألتقط الصور من جديد الليلة.",
+        threadOneMore: "ممتاز. أمر أخير —",
+        threadBadge: "هل يمكن أن تستخدم شارة غير المقروء لون التمييز؟",
+        threadAlreadyDone: "تم ذلك بالفعل، أرفع التعديل الآن.",
+        threadThanks: "أنت رائعة، شكرًا جزيلًا!"
+    )
+}
+
+// MARK: - Environment
+
+private struct StringsKey: EnvironmentKey {
+    static let defaultValue = Strings.english
+}
+
+extension EnvironmentValues {
+    /// Views read their copy from here; `ChatRootView` and the snapshot helpers
+    /// derive it from `\.locale`.
+    var strings: Strings {
+        get { self[StringsKey.self] }
+        set { self[StringsKey.self] = newValue }
+    }
+}
+
+extension View {
+    /// Renders this view in `locale`, wiring up both the copy and the layout
+    /// direction (Arabic flips to right-to-left).
+    func chatLocale(_ locale: Locale) -> some View {
+        environment(\.locale, locale)
+            .environment(\.strings, Strings.forLocale(locale))
+            .environment(\.layoutDirection, locale.identifier.hasPrefix("ar") ? .rightToLeft : .leftToRight)
+    }
+}

--- a/SimpleProjectTests/ChatComponentSnapshotTests.swift
+++ b/SimpleProjectTests/ChatComponentSnapshotTests.swift
@@ -1,0 +1,208 @@
+//
+//  ChatComponentSnapshotTests.swift
+//  SimpleProjectTests
+//
+//  Component-level snapshots. These are cheap, fast, and pinpoint exactly which
+//  piece of the UI moved when a screen-level snapshot changes.
+//
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import SimpleProject
+
+final class ChatComponentSnapshotTests: XCTestCase {
+
+    private let strings = TestLocale.english.strings
+
+    // MARK: Bubbles
+
+    func testIncomingTextBubble() {
+        let message = Message(
+            id: 1, author: .them,
+            body: .text(strings.threadHello),
+            sentAt: ChatClock.date(2025, 6, 12, 9, 12)
+        )
+        assertComponentSnapshot(MessageBubbleView(message: message))
+    }
+
+    func testOutgoingTextBubble() {
+        let message = Message(
+            id: 1, author: .me,
+            body: .text(strings.threadReply),
+            sentAt: ChatClock.date(2025, 6, 12, 9, 15),
+            status: .read
+        )
+        assertComponentSnapshot(MessageBubbleView(message: message))
+    }
+
+    /// A message long enough to wrap several times, to catch bubble width and
+    /// line-break regressions.
+    func testLongTextBubble() {
+        let message = Message(
+            id: 1, author: .them,
+            body: .text(
+                """
+                Reviewed the whole flow this morning — the inbox, the thread, \
+                the empty state and the composer. Only thing left is the badge \
+                colour, everything else looks ready to ship.
+                """
+            ),
+            sentAt: ChatClock.date(2025, 6, 12, 9, 20)
+        )
+        assertComponentSnapshot(MessageBubbleView(message: message))
+    }
+
+    func testPhotoBubbleWithCaptionAndReaction() {
+        let message = Message(
+            id: 1, author: .them,
+            body: .photo(caption: strings.threadPhotoCaption, tint: .purple),
+            sentAt: ChatClock.date(2025, 6, 12, 9, 41),
+            reactions: [Reaction(id: 1, emoji: "🔥", count: 2)]
+        )
+        assertComponentSnapshot(MessageBubbleView(message: message))
+    }
+
+    func testVoiceNoteBubble() {
+        let conversation = SampleData.mayaThread(strings)
+        let voiceNote = conversation.messages[0]
+        assertComponentSnapshot(MessageBubbleView(message: voiceNote))
+    }
+
+    func testFileAttachmentBubble() {
+        let message = Message(
+            id: 1, author: .them,
+            body: .file(name: "Design-System-v4.pdf", size: "2.4 MB"),
+            sentAt: ChatClock.date(2025, 6, 12, 16, 12)
+        )
+        assertComponentSnapshot(MessageBubbleView(message: message))
+    }
+
+    func testReplyQuoteBubble() {
+        let message = Message(
+            id: 1, author: .me,
+            body: .text(strings.threadAlreadyDone),
+            sentAt: ChatClock.date(2025, 6, 12, 16, 5),
+            status: .delivered,
+            replyingTo: (author: "Maya Ferreira", text: strings.threadBadge)
+        )
+        assertComponentSnapshot(MessageBubbleView(message: message))
+    }
+
+    /// All four delivery states side by side.
+    func testDeliveryStatuses() {
+        let statuses: [DeliveryStatus] = [.sending, .sent, .delivered, .read]
+        let stack = VStack(alignment: .trailing, spacing: 6) {
+            ForEach(Array(statuses.enumerated()), id: \.offset) { index, status in
+                MessageBubbleView(
+                    message: Message(
+                        id: index, author: .me,
+                        body: .text(["Sending…", "Sent", "Delivered", "Read"][index]),
+                        sentAt: ChatClock.date(2025, 6, 12, 16, index),
+                        status: status
+                    )
+                )
+            }
+        }
+        assertComponentSnapshot(stack)
+    }
+
+    // MARK: List rows
+
+    func testConversationRows() {
+        let rows = VStack(spacing: 0) {
+            ForEach(SampleData.conversations(strings)) { conversation in
+                ConversationRow(conversation: conversation)
+                Divider().padding(.leading, 64)
+            }
+        }
+        assertComponentSnapshot(rows, width: 375)
+    }
+
+    func testConversationRowStates() {
+        let all = SampleData.conversations(strings)
+        let interesting = [
+            all[1],  // muted group with a large unread count
+            all[2],  // someone typing
+            all[3],  // voice-note preview
+            all[5],  // outgoing message with delivery ticks
+        ]
+        let rows = VStack(spacing: 0) {
+            ForEach(interesting) { conversation in
+                ConversationRow(conversation: conversation)
+                Divider().padding(.leading, 64)
+            }
+        }
+        assertComponentSnapshot(rows, width: 375)
+    }
+
+    // MARK: Small parts
+
+    func testAvatars() {
+        let contacts = [
+            SampleData.maya(strings),
+            SampleData.devTeam(strings),
+            SampleData.marco(strings),
+            SampleData.priya(strings),
+        ]
+        let row = HStack(spacing: 14) {
+            ForEach(contacts) { contact in
+                AvatarView(contact: contact)
+            }
+        }
+        assertComponentSnapshot(row, width: 300)
+    }
+
+    func testUnreadBadges() {
+        let row = HStack(spacing: 12) {
+            UnreadBadge(count: 1)
+            UnreadBadge(count: 9)
+            UnreadBadge(count: 12)
+            UnreadBadge(count: 128)
+            UnreadBadge(count: 12, muted: true)
+        }
+        assertComponentSnapshot(row, width: 260)
+    }
+
+    func testTypingIndicator() {
+        assertComponentSnapshot(
+            HStack { TypingIndicatorView(); Spacer() },
+            width: 200
+        )
+    }
+
+    func testDaySeparatorAndUnreadDivider() {
+        let stack = VStack(spacing: 0) {
+            DaySeparator(label: strings.yesterday)
+            DaySeparator(label: strings.today)
+            UnreadDivider(label: strings.unreadDivider)
+        }
+        assertComponentSnapshot(stack)
+    }
+
+    func testComposerStates() {
+        let stack = VStack(spacing: 16) {
+            ChatComposer()
+            ChatComposer(draft: "Already done, pushing the change now.")
+            ChatComposer(
+                draft: """
+                    Long draft that wraps onto several lines so we can see how \
+                    the composer grows with the text it contains.
+                    """
+            )
+        }
+        assertComponentSnapshot(stack, width: 375)
+    }
+
+    func testTabBar() {
+        assertComponentSnapshot(ChatTabBar(unreadCount: 15), width: 375)
+    }
+
+    func testEmptyState() {
+        assertComponentSnapshot(
+            ChatEmptyStateView().frame(height: 420),
+            width: 375
+        )
+    }
+}

--- a/SimpleProjectTests/ChatSnapshotTests.swift
+++ b/SimpleProjectTests/ChatSnapshotTests.swift
@@ -1,0 +1,101 @@
+//
+//  ChatSnapshotTests.swift
+//  SimpleProjectTests
+//
+//  Full-screen snapshots of the chat app, each captured in light and dark mode.
+//
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import SimpleProject
+
+final class ChatSnapshotTests: XCTestCase {
+
+    private let strings = TestLocale.english.strings
+
+    // MARK: Inbox
+
+    func testConversationList() {
+        assertScreenSnapshot(
+            ConversationListView(conversations: SampleData.conversations(strings))
+        )
+    }
+
+    func testConversationListOnSmallDevice() {
+        assertScreenSnapshot(
+            ConversationListView(conversations: SampleData.conversations(strings)),
+            device: .iPhoneSe
+        )
+    }
+
+    func testConversationListOnLargeDevice() {
+        assertScreenSnapshot(
+            ConversationListView(conversations: SampleData.conversations(strings)),
+            device: .iPhone13ProMax
+        )
+    }
+
+    func testConversationListWhenEmpty() {
+        assertScreenSnapshot(ConversationListView(conversations: []))
+    }
+
+    /// One unread conversation, no pins — the state right after onboarding.
+    func testConversationListWithSingleThread() {
+        let conversations = [SampleData.freshThread(strings)]
+        assertScreenSnapshot(ConversationListView(conversations: conversations))
+    }
+
+    // MARK: Conversation
+
+    func testChatDetail() {
+        assertScreenSnapshot(
+            ChatDetailView(conversation: SampleData.mayaThread(strings))
+        )
+    }
+
+    func testChatDetailOnSmallDevice() {
+        assertScreenSnapshot(
+            ChatDetailView(conversation: SampleData.mayaThread(strings)),
+            device: .iPhoneSe
+        )
+    }
+
+    func testChatDetailWhileTyping() {
+        assertScreenSnapshot(
+            ChatDetailView(conversation: SampleData.mayaThreadTyping(strings))
+        )
+    }
+
+    func testChatDetailWithDraft() {
+        assertScreenSnapshot(
+            ChatDetailView(
+                conversation: SampleData.mayaThreadTyping(strings),
+                draft: "Pushing a fix for the badge colour now — should be on TestFlight in ten."
+            )
+        )
+    }
+
+    func testChatDetailForNewConversation() {
+        assertScreenSnapshot(
+            ChatDetailView(conversation: SampleData.freshThread(strings))
+        )
+    }
+
+    func testChatDetailForGroup() {
+        let conversations = SampleData.conversations(strings)
+        let group = conversations.first { $0.contact.isGroup }!
+        assertScreenSnapshot(ChatDetailView(conversation: group))
+    }
+
+    // MARK: App entry points
+
+    func testRootView() {
+        assertScreenSnapshot(ContentView())
+    }
+
+    func testLoginScreen() {
+        assertScreenSnapshot(LoginView())
+    }
+}

--- a/SimpleProjectTests/DynamicTypeSnapshotTests.swift
+++ b/SimpleProjectTests/DynamicTypeSnapshotTests.swift
@@ -1,0 +1,69 @@
+//
+//  DynamicTypeSnapshotTests.swift
+//  SimpleProjectTests
+//
+//  Accessibility text sizes. Layouts that look fine at the default size are
+//  usually where truncation and clipping first appear.
+//
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import SimpleProject
+
+final class DynamicTypeSnapshotTests: XCTestCase {
+
+    private let strings = TestLocale.english.strings
+
+    private let sizes: [TestTypeSize] = [.extraLarge, .accessibility]
+
+    func testConversationList() {
+        for size in sizes {
+            assertScreenSnapshot(
+                ConversationListView(conversations: SampleData.conversations(strings)),
+                named: size.tag,
+                typeSize: size
+            )
+        }
+    }
+
+    func testChatDetail() {
+        for size in sizes {
+            assertScreenSnapshot(
+                ChatDetailView(conversation: SampleData.mayaThread(strings)),
+                named: size.tag,
+                typeSize: size
+            )
+        }
+    }
+
+    /// Largest text on the smallest screen — the worst case.
+    func testChatDetailOnSmallDevice() {
+        assertScreenSnapshot(
+            ChatDetailView(conversation: SampleData.mayaThread(strings)),
+            device: .iPhoneSe,
+            typeSize: .accessibility
+        )
+    }
+
+    func testEmptyState() {
+        assertScreenSnapshot(
+            ConversationListView(conversations: []),
+            typeSize: .accessibility
+        )
+    }
+
+    func testConversationRow() {
+        for size in sizes {
+            let conversations = SampleData.conversations(strings)
+            let rows = VStack(spacing: 0) {
+                ForEach(conversations.prefix(3)) { conversation in
+                    ConversationRow(conversation: conversation)
+                    Divider().padding(.leading, 64)
+                }
+            }
+            assertComponentSnapshot(rows, named: size.tag, width: 375, typeSize: size)
+        }
+    }
+}

--- a/SimpleProjectTests/LocalizationSnapshotTests.swift
+++ b/SimpleProjectTests/LocalizationSnapshotTests.swift
@@ -1,0 +1,109 @@
+//
+//  LocalizationSnapshotTests.swift
+//  SimpleProjectTests
+//
+//  The same screens in every language we ship, light and dark. German catches
+//  long compound words, Japanese catches line breaking and glyph height, and
+//  Arabic flips the whole layout to right-to-left.
+//
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import SimpleProject
+
+final class LocalizationSnapshotTests: XCTestCase {
+
+    /// Inbox in all five languages: `testConversationList.es-light.png` and friends.
+    func testConversationList() {
+        for testLocale in TestLocale.allCases {
+            assertScreenSnapshot(
+                ConversationListView(conversations: SampleData.conversations(testLocale.strings)),
+                named: testLocale.tag,
+                locale: testLocale
+            )
+        }
+    }
+
+    /// Thread view in all five languages.
+    func testChatDetail() {
+        for testLocale in TestLocale.allCases {
+            assertScreenSnapshot(
+                ChatDetailView(conversation: SampleData.mayaThread(testLocale.strings)),
+                named: testLocale.tag,
+                locale: testLocale
+            )
+        }
+    }
+
+    /// Empty state, where the copy is longest and most likely to overflow.
+    func testEmptyState() {
+        for testLocale in TestLocale.allCases {
+            assertScreenSnapshot(
+                ConversationListView(conversations: []),
+                named: testLocale.tag,
+                locale: testLocale
+            )
+        }
+    }
+
+    /// Right-to-left needs the tightest screen too: bubbles, ticks and the
+    /// composer all mirror.
+    func testRightToLeftOnSmallDevice() {
+        assertScreenSnapshot(
+            ChatDetailView(
+                conversation: SampleData.mayaThreadTyping(TestLocale.arabic.strings),
+                draft: TestLocale.arabic.strings.threadAlreadyDone
+            ),
+            device: .iPhoneSe,
+            locale: .arabic
+        )
+    }
+
+    /// German is the longest of the translations; the composer and tab bar are
+    /// where it shows first.
+    func testGermanComposerAndTabBar() {
+        let stack = VStack(spacing: 16) {
+            ChatComposer()
+            ChatComposer(draft: TestLocale.german.strings.threadAlreadyDone)
+            ChatTabBar(unreadCount: 15)
+        }
+        assertComponentSnapshot(stack, width: 375, locale: .german)
+    }
+
+    /// Message bubbles on their own, per language — the fastest way to eyeball
+    /// a translation change.
+    func testMessageBubbles() {
+        for testLocale in TestLocale.allCases {
+            let strings = testLocale.strings
+            let stack = VStack(alignment: .leading, spacing: 6) {
+                MessageBubbleView(
+                    message: Message(
+                        id: 1, author: .them,
+                        body: .text(strings.threadHello),
+                        sentAt: ChatClock.date(2025, 6, 12, 9, 12)
+                    )
+                )
+                MessageBubbleView(
+                    message: Message(
+                        id: 2, author: .me,
+                        body: .text(strings.threadReply),
+                        sentAt: ChatClock.date(2025, 6, 12, 9, 15),
+                        status: .read
+                    )
+                )
+                MessageBubbleView(
+                    message: Message(
+                        id: 3, author: .me,
+                        body: .text(strings.threadAlreadyDone),
+                        sentAt: ChatClock.date(2025, 6, 12, 16, 5),
+                        status: .delivered,
+                        replyingTo: (author: "Maya Ferreira", text: strings.threadBadge)
+                    )
+                )
+            }
+            assertComponentSnapshot(stack, named: testLocale.tag, locale: testLocale)
+        }
+    }
+}

--- a/SimpleProjectTests/SimpleProjectTests.swift
+++ b/SimpleProjectTests/SimpleProjectTests.swift
@@ -12,36 +12,16 @@ import SnapshotTesting
 
 final class SimpleProjectTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-        let view = ContentView()
-        assertSnapshot(matching: view, as: .image)
-    }
     func testDataSnapshot() throws {
         let data = "foobar"
         //Data snapshots do not work on XCode cloud
         //assertSnapshot(matching: data, as: .dump)
     }
-    
+
+    /// The original login screen snapshot, kept in its plain sizeThatFits form.
+    /// The chat screens use the helpers in `SnapshotSupport.swift` instead.
     func testLoginViewSnapshot() throws {
         let loginView = LoginView()
         assertSnapshot(matching: loginView, as: .image)
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-    }
-
 }

--- a/SimpleProjectTests/SnapshotSupport.swift
+++ b/SimpleProjectTests/SnapshotSupport.swift
@@ -1,0 +1,160 @@
+//
+//  SnapshotSupport.swift
+//  SimpleProjectTests
+//
+//  Shared plumbing for the chat snapshot tests.
+//
+//  Every screen is captured twice — light and dark — and every axis that could
+//  drift between machines (locale, layout direction, dynamic type, display
+//  scale, time zone) is pinned explicitly here rather than inherited from the
+//  simulator.
+//
+//  Re-record everything with:
+//
+//      RECORD_SNAPSHOTS=1 xcodebuild test -scheme SimpleProject \
+//          -destination 'platform=iOS Simulator,name=iPhone SE (3rd generation)'
+//
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import SimpleProject
+
+/// Set `RECORD_SNAPSHOTS=1` in the environment to overwrite the reference images.
+let isRecordingSnapshots = ProcessInfo.processInfo.environment["RECORD_SNAPSHOTS"] == "1"
+
+/// The languages the app ships. Arabic doubles as the right-to-left case.
+enum TestLocale: String, CaseIterable {
+    case english = "en_US"
+    case spanish = "es_ES"
+    case german = "de_DE"
+    case japanese = "ja_JP"
+    case arabic = "ar_EG"
+
+    var locale: Locale { Locale(identifier: rawValue) }
+
+    /// Short tag used in snapshot file names, e.g. `testChatDetail.ja-dark.png`.
+    var tag: String { String(rawValue.prefix(2)) }
+
+    var strings: Strings { Strings.forLocale(locale) }
+}
+
+/// Dynamic type sizes exercised by `DynamicTypeSnapshotTests`, paired so the
+/// SwiftUI environment and the UIKit trait collection always agree.
+struct TestTypeSize {
+    let tag: String
+    let swiftUI: ContentSizeCategory
+    let uiKit: UIContentSizeCategory
+
+    static let standard = TestTypeSize(tag: "standard", swiftUI: .large, uiKit: .large)
+    static let extraLarge = TestTypeSize(tag: "xxxl", swiftUI: .extraExtraExtraLarge,
+                                         uiKit: .extraExtraExtraLarge)
+    static let accessibility = TestTypeSize(tag: "a11y-xl", swiftUI: .accessibilityExtraLarge,
+                                            uiKit: .accessibilityExtraLarge)
+}
+
+extension ColorScheme {
+    var tag: String { self == .dark ? "dark" : "light" }
+
+    var userInterfaceStyle: UIUserInterfaceStyle { self == .dark ? .dark : .light }
+}
+
+extension XCTestCase {
+
+    /// Captures a full screen on `device`, once per color scheme.
+    ///
+    /// - Parameters:
+    ///   - name: Optional variant prefix; the color scheme is always appended,
+    ///     so a snapshot ends up named `testChatDetail.<name>-dark.png`.
+    func assertScreenSnapshot<V: View>(
+        _ view: V,
+        named name: String? = nil,
+        device: ViewImageConfig = .iPhone13,
+        locale: TestLocale = .english,
+        typeSize: TestTypeSize = .standard,
+        colorSchemes: [ColorScheme] = [.light, .dark],
+        file: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        for scheme in colorSchemes {
+            let configured =
+                view
+                .chatLocale(locale.locale)
+                .environment(\.colorScheme, scheme)
+                .environment(\.sizeCategory, typeSize.swiftUI)
+
+            assertSnapshot(
+                of: configured,
+                as: .image(
+                    layout: .device(config: device),
+                    traits: traits(scheme: scheme, locale: locale, typeSize: typeSize)
+                ),
+                named: [name, scheme.tag].compactMap { $0 }.joined(separator: "-"),
+                record: isRecordingSnapshots,
+                file: file,
+                testName: testName,
+                line: line
+            )
+        }
+    }
+
+    /// Captures a single component sized to its content, on a plain background,
+    /// once per color scheme.
+    func assertComponentSnapshot<V: View>(
+        _ view: V,
+        named name: String? = nil,
+        width: CGFloat = 340,
+        locale: TestLocale = .english,
+        typeSize: TestTypeSize = .standard,
+        colorSchemes: [ColorScheme] = [.light, .dark],
+        file: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        for scheme in colorSchemes {
+            let configured =
+                view
+                .frame(width: width)
+                .padding(12)
+                .background(Color(uiColor: .systemBackground))
+                .chatLocale(locale.locale)
+                .environment(\.colorScheme, scheme)
+                .environment(\.sizeCategory, typeSize.swiftUI)
+
+            assertSnapshot(
+                of: configured,
+                as: .image(
+                    layout: .sizeThatFits,
+                    traits: traits(scheme: scheme, locale: locale, typeSize: typeSize, displayScale: 2)
+                ),
+                named: [name, scheme.tag].compactMap { $0 }.joined(separator: "-"),
+                record: isRecordingSnapshots,
+                file: file,
+                testName: testName,
+                line: line
+            )
+        }
+    }
+
+    /// UIKit side of the environment. SwiftUI resolves semantic colors such as
+    /// `.systemBackground` through the hosting view's traits, so the style has
+    /// to be set here as well as in the SwiftUI environment.
+    private func traits(
+        scheme: ColorScheme,
+        locale: TestLocale,
+        typeSize: TestTypeSize,
+        displayScale: CGFloat? = nil
+    ) -> UITraitCollection {
+        var collections: [UITraitCollection] = [
+            UITraitCollection(userInterfaceStyle: scheme.userInterfaceStyle),
+            UITraitCollection(preferredContentSizeCategory: typeSize.uiKit),
+            UITraitCollection(layoutDirection: locale == .arabic ? .rightToLeft : .leftToRight),
+        ]
+        if let displayScale {
+            collections.append(UITraitCollection(displayScale: displayScale))
+        }
+        return UITraitCollection(traitsFrom: collections)
+    }
+}


### PR DESCRIPTION
Adds a small but realistic chat UI (inbox, thread, composer, empty state) and snapshot tests over it. Everything the snapshots depend on is pinned in code — fixture dates in UTC, translations in Swift, display scale, layout direction — so the images only change when the UI does.

Tests cover light + dark for every screen, five languages including a right-to-left one, several devices, and accessibility text sizes.